### PR TITLE
Add support for running migrations when deploying umbrella apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ deploy:
         GIGALIXIR_APP: my-gigalixir-app # Feel free to also put this in your secrets
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         MIGRATIONS: false  # defaults to true
+        MIGRATION_APP_NAME: "" # optional, defaults to an empty string
         APP_SUBFOLDER: my-app-subfolder  # Add only if you want to deploy an app that is not at the root of your repository
 ```
 
@@ -41,6 +42,7 @@ deploy:
 Currently running migrations is only supported when your app is deployed as a mix release.
 
 The migrations are run with the `gigalixir ps:migrate` command, which requires having a public key uploaded to your app's container and a private key locally to connect via an `ssh` connection.
+If you're deploying an umbrella app, you likely want to set the `MIGRATION_APP_NAME` option to the name of app containing your migrations.
 
 Please see the docs for [How to Run Migrations](https://gigalixir.readthedocs.io/en/latest/main.html#migrations) for more information.
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Configuration for migrations'
     required: true
     default: true
+  MIGRATION_APP_NAME:
+    description: 'Name of the app that contains migrations (useful for umbrella apps)'
+    required: false
+    default: ""
   APP_SUBFOLDER:
     description: 'Subfolder of your app'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1093,6 +1093,7 @@ async function run() {
     const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', baseInputOptions);
     const gigalixirApp = core.getInput('GIGALIXIR_APP', baseInputOptions);
     const migrations = core.getInput('MIGRATIONS', baseInputOptions);
+    const migrationAppName = core.getInput('MIGRATION_APP_NAME', baseInputOptions);
     const appSubfolder = core.getInput('APP_SUBFOLDER', { required: false });
 
     await core.group("Installing gigalixir", async () => {
@@ -1132,7 +1133,13 @@ async function run() {
 
       try {
         await core.group("Running migrations", async () => {
-          await exec.exec(`gigalixir ps:migrate -a ${gigalixirApp}`)
+          const args = [ "ps:migrate", `--app_name=${gigalixirApp}` ]
+
+          if (migrationAppName.length > 0) {
+            args.push(`--migration_app_name="${migrationAppName}"`)
+          }
+
+          await exec.exec("gigalixir", args)
         });
       } catch (error) {
         if (currentRelease === 0) {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ async function run() {
     const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', baseInputOptions);
     const gigalixirApp = core.getInput('GIGALIXIR_APP', baseInputOptions);
     const migrations = core.getInput('MIGRATIONS', baseInputOptions);
+    const migrationAppName = core.getInput('MIGRATION_APP_NAME', baseInputOptions);
     const appSubfolder = core.getInput('APP_SUBFOLDER', { required: false });
 
     await core.group("Installing gigalixir", async () => {
@@ -124,7 +125,13 @@ async function run() {
 
       try {
         await core.group("Running migrations", async () => {
-          await exec.exec(`gigalixir ps:migrate -a ${gigalixirApp}`)
+          const args = [ "ps:migrate", `--app_name=${gigalixirApp}` ]
+
+          if (migrationAppName.length > 0) {
+            args.push(`--migration_app_name="${migrationAppName}"`)
+          }
+
+          await exec.exec("gigalixir", args)
         });
       } catch (error) {
         if (currentRelease === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When using `gigalixir ps:migrate` with umbrella apps, you have to pass the name of the application that contains your migrations. This commit introduces a `MIGRATION_APP_NAME` option that lets you do that.

I have verified that it works for my case, though I haven't validated this change __without__ an umbrella app.