### PR TITLE
Authenticate the Gigalixir CLI with an API key instead of interactive login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,19 @@ deploy:
         GIGALIXIR_APP: my-gigalixir-app # Feel free to also put this in your secrets
         GIGALIXIR_CLEAN: true # defaults to false
         GIGALIXIR_USERNAME: ${{ secrets.GIGALIXIR_USERNAME }}
-        GIGALIXIR_PASSWORD: ${{ secrets.GIGALIXIR_PASSWORD }}
+        GIGALIXIR_PASSWORD: ${{ secrets.GIGALIXIR_PASSWORD }} # Use GIGALIXIR_PASSWORD or GIGALIXIR_API_KEY
+        GIGALIXIR_API_KEY: ${{ secrets.GIGALIXIR_API_KEY }} # Use GIGALIXIR_PASSWORD or GIGALIXIR_API_KEY
         MIGRATIONS: false  # defaults to true
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 ```
+
+## Gigalixir CLI Authentication
+
+The default strategy for authenticating the Gigalixir CLI logs in with `GIGALIXIR_USERNAME` and `GIGALIXIR_PASSWORD`. However, if MFA is enabled on the account the login prompt becomes interactive (asking for the MFA token).
+
+However, the authentication actually shoves an API key into your `~/.netrc` which the [CLI uses](https://gigalixir.readthedocs.io/en/latest/cli.html?highlight=netrc#authentication) when executing commands. You can find your API key on the Gigalixir dashboard under Account > API Key.
+
+By supplying `GIGALIXIR_API_KEY` instead of `GIGALIXIR_PASSWORD` you can enable MFA on the account associated with deploying the application and still use this action! See the [Gigalixir documentation](https://gigalixir.readthedocs.io/en/latest/account.html?highlight=api%20key#how-to-use-multi-factor-authentication) for the steps to enable MFA.
 
 ## Migrations
 

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,12 @@ inputs:
   GIGALIXIR_USERNAME:
     description: 'Your Gigalixir username'
     required: true
+  GIGALIXIR_API_KEY:
+    description: 'Your Gigalixir API key'
+    required: false
   GIGALIXIR_PASSWORD:
     description: 'Your Gigalixir password'
-    required: true
+    required: false
   MIGRATIONS:
     description: 'Configuration for migrations'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Your Gigalixir username'
     required: true
   GIGALIXIR_API_KEY:
-    description: 'Your Gigalixir API key'
+    description: 'Your Gigalixir API key -- either this option or GIGALIXIR_PASSWORD should be used'
     required: false
   GIGALIXIR_PASSWORD:
-    description: 'Your Gigalixir password'
+    description: 'Your Gigalixir password -- either this option or GIGALIXIR_API_KEY should be used'
     required: false
   MIGRATIONS:
     description: 'Configuration for migrations'

--- a/bin/add-gigalixir-api-key
+++ b/bin/add-gigalixir-api-key
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+set -ev
+
+NETRC="$HOME/.netrc"
+
+touch $NETRC
+
+printf "machine api.gigalixir.com\n" >> $NETRC
+printf "login %s\n" "$1" >> $NETRC
+printf "password %s\n" "$2" >> $NETRC
+
+printf "\n">> $NETRC
+
+printf "machine git.gigalixir.com\n" >> $NETRC
+printf "login %s\n" "$1" >> $NETRC
+printf "password %s\n" "$2" >> $NETRC
+
+chmod 644 $NETRC

--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ async function run() {
     const gigalixirApp = core.getInput('GIGALIXIR_APP', {required: true});
     const gigalixirClean = core.getInput('GIGALIXIR_CLEAN', {required: false});
     const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', {required: true});
-    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', {required: true});
+    const gigalixirApiKey = core.getInput('GIGALIXIR_API_KEY', {required: false});
+    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', {required: false});
     const migrations = core.getInput('MIGRATIONS', {required: true});
     const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', {required: JSON.parse(migrations)});
 
@@ -93,9 +94,15 @@ async function run() {
       await exec.exec('pip3 install gigalixir')
     });
 
-    await core.group("Logging in to gigalixir", async () => {
-      await exec.exec(`gigalixir login -e "${gigalixirUsername}" -y -p "${gigalixirPassword}"`)
-    });
+    if (gigalixirPassword) {
+      await core.group("Logging in to gigalixir", async () => {
+        await exec.exec(`gigalixir login -e "${gigalixirUsername}" -y -p "${gigalixirPassword}"`)
+      });
+    } else if (gigalixirApiKey) {
+      await core.group("Setting up ~/.netrc", async () => {
+        await exec.exec(path.join(__dirname, "../bin/add-gigalixir-api-key"), [gigalixirUsername, gigalixirApiKey]);
+      });
+    }
 
     await core.group("Setting git remote for gigalixir", async () => {
       await exec.exec(`gigalixir git:remote ${gigalixirApp}`);


### PR DESCRIPTION
I have MFA enabled on the account associated with deploying the application. The default CLI login becomes interactive in this case because it waits for the MFA token. However, all the login process does is shove an API key in `~/.netrc`. 

This PR makes the changes to populate `~/.netrc` with the given API key instead of relying on the interactive login. The changes are written in a way such that using the API key is opt-in and existing actions will continue to work.

Closes #44 